### PR TITLE
レベル消費じゃなくて経験値消費にする

### DIFF
--- a/src/main/java/com/github/kumo0621/magicstone/MagicStone.java
+++ b/src/main/java/com/github/kumo0621/magicstone/MagicStone.java
@@ -94,12 +94,13 @@ public final class MagicStone extends JavaPlugin implements Listener {
         String message = event.getMessage();
 
         if (message.startsWith("@")) {
-            int currentExp = player.getLevel();
+            int currentExp = XpUtils.getPlayerExperience(player);
             // 必要な経験値が足りているかチェック
-            if (currentExp >= 30) {
+            int xpLv30 = XpUtils.levelToExp(30);
+            if (currentExp >= xpLv30) {
                 aiReturn.ai(message, player);
-                player.setLevel(currentExp - 30);
-            } else {
+                XpUtils.setPlayerExperience(player, currentExp - xpLv30);
+            }else {
                 player.sendMessage("魔法を生成するのは30Lv必要です。");
             }
         }
@@ -209,8 +210,8 @@ public final class MagicStone extends JavaPlugin implements Listener {
 
 
     public void Magic(Player player, MagicData magicData) {
-        int cost = magicData.getPower() * magicData.getRange() /60/15;
-        int currentExp = player.getLevel();
+        int cost = XpUtils.levelToExp(magicData.getPower() * magicData.getRange() /60/15);
+        int currentExp = XpUtils.getPlayerExperience(player);
         // 必要な経験値が足りているかチェック
         if (currentExp >= cost) {
             switch (magicData.getProperties()) {
@@ -398,8 +399,7 @@ public final class MagicStone extends JavaPlugin implements Listener {
 
                 }
             }
-            double result = currentExp - cost;
-            player.setLevel((int) result);
+            XpUtils.setPlayerExperience(player, currentExp - cost);
         }else {
             player.sendMessage("経験値が足りない。");
         }
@@ -739,10 +739,12 @@ public final class MagicStone extends JavaPlugin implements Listener {
                     return;
                 }
 
+                int xpLv30 = XpUtils.levelToExp(30);
                 int expUsed = playerExpUsage.get(playerId) + 1;
-                if (expUsed <= 30) {
-                    if (player.getLevel() > 0) {
-                        player.setLevel(player.getLevel() - 1);
+                if (expUsed <= xpLv30) {
+                    int playerXp = XpUtils.getPlayerExperience(player);
+                    if (playerXp > 0) {
+                        XpUtils.setPlayerExperience(player, playerXp - XpUtils.levelToExp(1));
                         playerExpUsage.put(playerId, expUsed);
                         player.getWorld().playSound(player.getLocation(), Sound.ENTITY_PLAYER_LEVELUP, 1.0F, 0.5F);
                     } else {

--- a/src/main/java/com/github/kumo0621/magicstone/XpUtils.java
+++ b/src/main/java/com/github/kumo0621/magicstone/XpUtils.java
@@ -1,0 +1,57 @@
+package com.github.kumo0621.magicstone;
+
+import org.bukkit.entity.Player;
+
+public class XpUtils {
+    public static int levelToExp(int level) {
+        if (level <= 15) {
+            return level * level + 6 * level;
+        } else {
+            return level <= 30 ? (int)(2.5 * (double)level * (double)level - 40.5 * (double)level + 360.0) : (int)(4.5 * (double)level * (double)level - 162.5 * (double)level + 2220.0);
+        }
+    }
+
+    public static int deltaLevelToExp(int level) {
+        if (level <= 15) {
+            return 2 * level + 7;
+        } else {
+            return level <= 30 ? 5 * level - 38 : 9 * level - 158;
+        }
+    }
+
+    public static int currentLevelXpDelta(Player player) {
+        return deltaLevelToExp(player.getLevel()) - (levelToExp(player.getLevel()) + Math.round((float)deltaLevelToExp(player.getLevel()) * player.getExp()) - levelToExp(player.getLevel()));
+    }
+
+    public static int getPlayerExperience(Player player) {
+        return (int)((double)levelToExp(player.getLevel()) + Math.floor((float)deltaLevelToExp(player.getLevel()) * player.getExp()));
+    }
+
+    public static void setPlayerExperience(Player player, int xp) {
+        player.setTotalExperience(0);
+        player.setLevel(0);
+        player.setExp(0.0F);
+        player.setTotalExperience(0);
+        if (xp >= 1) {
+            player.giveExp(xp);
+            int xpForLevel = levelToExp(player.getLevel());
+            int delta = deltaLevelToExp(player.getLevel());
+            player.setExp((float)(xp - xpForLevel) / Float.valueOf((float)delta));
+        }
+    }
+
+    public static int expToLevel(double sourceLeftExp, double d) {
+        if (d > 21863.0) {
+            d = 21863.0;
+        }
+
+        for(int i = 1; (double)i <= d + 1.0; ++i) {
+            double levelExp = levelToExp(i);
+            if (levelExp > sourceLeftExp) {
+                return i - 1;
+            }
+        }
+
+        return 0;
+    }
+}


### PR DESCRIPTION
レベル消費じゃなくて経験値消費にします。

例えば40レベル持っている状態で30レベ使う魔法作成を行ったときに、30レベル分の経験値を使用して、40レベル→31レベルに減ります。

今回追加したクラスですが、今後経験値を使う処理を行う際に、以下を意識して置き換えてもらえればOKです
- `player.getLevel()` を行う際に `XpUtils.getPlayerExperience(player)` に変える
- `player.setLevel(数字)` を行う際に `XpUtils.setPlayerExperience(player, XpUtils.levelToExp(数字))` に変える
